### PR TITLE
Feature/track audio session progress

### DIFF
--- a/__tests___/Vibes.test.tsx
+++ b/__tests___/Vibes.test.tsx
@@ -218,7 +218,7 @@ describe('Vibes Component', () => {
     render(<MockedVibesWithAuth />);
 
     await waitFor(() => {
-      expect(console.error).toHaveBeenCalledWith('Detailed error loading sound:', error);
+      expect(console.error).toHaveBeenCalledWith('Error loading sound:', error);
     });
   });
 

--- a/components/AudioProgressManager.tsx
+++ b/components/AudioProgressManager.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Audio } from 'expo-av';
+import { Track } from '../types';
+
+const POSITION_UPDATE_INTERVAL = 1000;
+const POSITION_STORAGE_KEY = '@audioPosition';
+const PLAYBACK_STATE_KEY = '@playbackState';
+
+interface AudioProgressManagerProps {
+  currentTrack: Track | null;
+  sound: Audio.Sound | undefined;
+  onPositionRestore: (position: number) => Promise<void>;
+  onPlaybackStateRestore: (isPlaying: boolean) => Promise<void>;
+}
+
+const AudioProgressManager: React.FC<AudioProgressManagerProps> = ({
+  currentTrack,
+  sound,
+  onPositionRestore,
+  onPlaybackStateRestore,
+}) => {
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout;
+
+    const savePlaybackState = async () => {
+      if (!sound || !currentTrack) return;
+
+      try {
+        const status = await sound.getStatusAsync();
+        if (!status.isLoaded) return;
+
+        // Save both position and playback state
+        const playbackData = {
+          position: status.positionMillis,
+          isPlaying: status.isPlaying,
+          trackId: currentTrack.id,
+          timestamp: Date.now(),
+        };
+
+        await AsyncStorage.setItem(PLAYBACK_STATE_KEY, JSON.stringify(playbackData));
+      } catch (error) {
+        console.error('Error saving playback state:', error);
+      }
+    };
+
+    const restorePlaybackState = async () => {
+      try {
+        const savedStateString = await AsyncStorage.getItem(PLAYBACK_STATE_KEY);
+        if (!savedStateString || !currentTrack) return;
+
+        const savedState = JSON.parse(savedStateString);
+
+        // Only restore if it's the same track and within last hour
+        const isRecent = Date.now() - savedState.timestamp < 60 * 60 * 1000;
+        if (savedState.trackId === currentTrack.id && isRecent) {
+          await onPositionRestore(savedState.position);
+          await onPlaybackStateRestore(savedState.isPlaying);
+        }
+      } catch (error) {
+        console.error('Error restoring playback state:', error);
+      }
+    };
+
+    // Start periodic saving
+    intervalId = setInterval(savePlaybackState, POSITION_UPDATE_INTERVAL);
+
+    // Restore state when component mounts
+    restorePlaybackState();
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+      // Save state one final time when unmounting
+      savePlaybackState();
+    };
+  }, [currentTrack, sound, onPositionRestore, onPlaybackStateRestore]);
+
+  return null;
+};
+
+export default AudioProgressManager;

--- a/components/Vibes.tsx
+++ b/components/Vibes.tsx
@@ -381,7 +381,7 @@ const Vibes: React.FC = () => {
       const data = response.data;
 
       const formattedTracks: Track[] = data.map((track: any) => ({
-        id: track.id,
+        id: `${track.id}`,
         title: track.title,
         file: track.url,
         category: track.audio_type,
@@ -390,6 +390,7 @@ const Vibes: React.FC = () => {
       setTracks(formattedTracks);
 
       const lastTrackId = (await AsyncStorage.getItem('@lastTrackId')) || '1';
+
       const track = formattedTracks.find((t) => t.id === lastTrackId) || formattedTracks[0];
       await loadSound(track);
 
@@ -443,7 +444,7 @@ const Vibes: React.FC = () => {
     }
   };
 
-  const handleSave = async (interval: any, selectedTrack: Track | undefined) => {
+  const handleSave = async (interval: any, selectedTrack: Track | null) => {
     try {
       await AsyncStorage.setItem(
         '@transitionSettings',
@@ -456,15 +457,18 @@ const Vibes: React.FC = () => {
         ...prev,
         interval,
       }));
+
       if (sound) {
         const playbackStatus = await sound.getStatusAsync();
         if (playbackStatus.isLoaded && playbackStatus.isPlaying) {
           await sound.pauseAsync();
         }
       }
-      setTimeout(async () => {
-        await loadSound(selectedTrack);
-      }, 1000);
+      if (selectedTrack) {
+        setTimeout(async () => {
+          await loadSound(selectedTrack);
+        }, 1000);
+      }
     } catch (error) {
       console.error('Error saving settings:', error);
       Alert.alert('Error', 'Failed to save settings');
@@ -472,7 +476,7 @@ const Vibes: React.FC = () => {
   };
 
   const loadSound = useCallback(
-    async (track = currentTrack) => {
+    async (track = currentTrack || tracks[0]) => {
       try {
         if (sound) {
           await sound.unloadAsync();

--- a/components/Vibes.tsx
+++ b/components/Vibes.tsx
@@ -326,8 +326,9 @@ const Vibes: React.FC = () => {
           } catch (error) {
             console.error('Cleanup error:', error);
           }
+          CacheService.clearOldCache();
+
         }
-        CacheService.clearOldCache();
       };
 
       cleanup();

--- a/components/Vibes.tsx
+++ b/components/Vibes.tsx
@@ -337,8 +337,8 @@ const Vibes: React.FC = () => {
           } catch (error) {
             console.error('Cleanup error:', error);
           }
+          CacheService.clearOldCache();
         }
-        CacheService.clearOldCache();
       };
 
       cleanup();

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -6,3 +6,5 @@ beforeAll(() => {
 afterAll(() => {
   jest.restoreAllMocks();
 });
+
+jest.setTimeout(30000);


### PR DESCRIPTION
## Pull Request Description: Track Audio Session Progress

### Overview
This pull request introduces a feature to track audio session progress, enhancing the user experience by allowing them to resume playback from where they left off. 

### Changes Made
- **Feature Implementation**: 
  - Added functionality to save the playback state of the audio, ensuring users can continue listening without losing their place.
  
- **Bug Fixes**: 
  - Resolved issues related to loading the last track ID settings, ensuring smoother user experience.
  - Modified the cleanup and initialization logic for sound references during navigation to prevent errors.
  
- **Tests**: 
  - Fixed existing tests that were breaking due to the changes, ensuring all tests pass successfully.

### Related Issues
- This PR addresses issues discussed in [[Issue #15](https://github.com/Bluette1/vibes/issues/15)](https://github.com/Bluette1/vibes/issues/15).

### Impact
By merging this feature, users will benefit from a more robust audio playback experience, with the ability to seamlessly resume their sessions.

